### PR TITLE
Use Qt 5 libraries

### DIFF
--- a/deb_base/control
+++ b/deb_base/control
@@ -10,7 +10,7 @@ Build-Depends:
   ninja-build,
   clang,
   lld,
-  qt6-declarative-dev,
+  qtdeclarative5-dev,
   python3,
   gzip,
   llvm,
@@ -50,15 +50,9 @@ Depends:
  fuse,
  squashfs-tools,
  zenity,
- libqt6quick6,
- libqt6widgets6t64,
- qml6-module-qtquick-controls,
- qml6-module-qtquick-layouts,
- qml6-module-qtquick-dialogs,
- qml6-module-qtquick-templates,
- qml6-module-qtquick-window,
- qml6-module-qtqml-workerscript,
- qml6-module-qt-labs-folderlistmodel,
+ qml-module-qtquick-controls,
+ qml-module-qtquick-controls2,
+ qml-module-qtquick-dialogs,
  ${shlibs:Depends}, ${misc:Depends}
 Recommends:
  erofs-utils (>= 1.5)


### PR DESCRIPTION
Ubuntu hasn't yet fully adopted Qt 6, so this is the better option for now.

I verified the created package works on a clean Ubuntu 24.04 distrobox without needing to manually install any further dependencies.